### PR TITLE
Sonar shouldn't trust all certificates and hosts as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+
+notifications:
+  email: false

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
       <dependency>
         <groupId>com.github.kevinsawicki</groupId>
         <artifactId>http-request</artifactId>
-        <version>4.1</version>
+        <version>5.6</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
       <dependency>
         <groupId>com.github.kevinsawicki</groupId>
         <artifactId>http-request</artifactId>
-        <version>5.6</version>
+        <version>4.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/sonar-runner-impl/src/main/java/org/sonar/runner/impl/ServerConnection.java
+++ b/sonar-runner-impl/src/main/java/org/sonar/runner/impl/ServerConnection.java
@@ -105,7 +105,6 @@ class ServerConnection {
 
   private HttpRequest newHttpRequest(URL url) {
     HttpRequest request = HttpRequest.get(url);
-    request.trustAllCerts().trustAllHosts();
     request.acceptGzipEncoding().uncompress(true);
     request.connectTimeout(CONNECT_TIMEOUT_MILLISECONDS).readTimeout(READ_TIMEOUT_MILLISECONDS);
     request.userAgent(userAgent);


### PR DESCRIPTION
I recently discovered that the Sonar runner is trusting all certificates and hosts as default.  Obviously this has security concerns.  I've removed the offending lines from the sonar-runner.  

This is causing issues due to an issue with the httprequest library detailed here:

https://github.com/kevinsawicki/http-request/pull/74

This means we cannot run the Sonar Server on a host requiring certificates.  

When you accept this change could you please update your related sonar-maven-plugin pom files so I can grab the new version and start using the plugin against my certificated host.

Furthermore, I had issues getting all the tests to pass before making the change.  Could you please confirm the exact goals you use to run them?

Mark