### PR TITLE
Deprecate sonar.verbose and replace it by sonar.logLevel

### DIFF
--- a/sonar-runner-batch/src/main/java/org/sonar/runner/batch/IsolatedLauncher.java
+++ b/sonar-runner-batch/src/main/java/org/sonar/runner/batch/IsolatedLauncher.java
@@ -64,11 +64,14 @@ public class IsolatedLauncher {
     jc.setContext(context);
     context.reset();
     InputStream input = Batch.class.getResourceAsStream("/org/sonar/batch/logback.xml");
-    System.setProperty("ROOT_LOGGER_LEVEL", isDebug(props) ? DEBUG : "INFO");
+    System.setProperty("ROOT_LOGGER_LEVEL", getLogLevel(props));
     context.putProperty("SQL_LOGGER_LEVEL", getSqlLevel(props));
     context.putProperty("SQL_RESULTS_LOGGER_LEVEL", getSqlResultsLevel(props));
     try {
       jc.doConfigure(input);
+      if (props.containsKey("sonar.verbose")) {
+        LoggerFactory.getLogger(getClass()).warn("sonar.verbose is deprecated, use sonar.logLevel instead");
+      }
 
     } catch (JoranException e) {
       throw new SonarException("can not initialize logging", e);
@@ -79,8 +82,9 @@ public class IsolatedLauncher {
   }
 
   @VisibleForTesting
-  protected boolean isDebug(Properties props) {
-    return Boolean.parseBoolean(props.getProperty("sonar.verbose", FALSE));
+  protected static String getLogLevel(Properties props) {
+    String fallback = Boolean.parseBoolean(props.getProperty("sonar.verbose", FALSE)) ? DEBUG : "INFO";
+    return props.getProperty("sonar.logLevel", fallback);
   }
 
   @VisibleForTesting

--- a/sonar-runner-batch/src/test/java/org/sonar/runner/batch/IsolatedLauncherTest.java
+++ b/sonar-runner-batch/src/test/java/org/sonar/runner/batch/IsolatedLauncherTest.java
@@ -67,10 +67,33 @@ public class IsolatedLauncherTest {
   }
 
   @Test
+  public void testGetLogLevel() throws Exception {
+    assertThat(IsolatedLauncher.getLogLevel(props)).isEqualTo("INFO");
+
+    props.setProperty("sonar.logLevel", "WARN");
+    assertThat(IsolatedLauncher.getLogLevel(props)).isEqualTo("WARN");
+
+    props.setProperty("sonar.logLevel", "ERROR");
+    assertThat(IsolatedLauncher.getLogLevel(props)).isEqualTo("ERROR");
+
+    props.setProperty("sonar.logLevel", "DEBUG");
+    assertThat(IsolatedLauncher.getLogLevel(props)).isEqualTo("DEBUG");
+  }
+
+  @Test
   public void shouldDetermineVerboseMode() {
-    assertThat(launcher.isDebug(props)).isFalse();
+    assertThat(IsolatedLauncher.getLogLevel(props)).isNotEqualTo("DEBUG");
 
     props.setProperty("sonar.verbose", "true");
-    assertThat(launcher.isDebug(props)).isTrue();
+    assertThat(IsolatedLauncher.getLogLevel(props)).isEqualTo("DEBUG");
+  }
+
+  @Test
+  public void shouldIgnoreVerboseModeIfLogLevelIsSet() {
+    props.setProperty("sonar.verbose", "true");
+    assertThat(IsolatedLauncher.getLogLevel(props)).isEqualTo("DEBUG");
+
+    props.setProperty("sonar.logLevel", "WARN");
+    assertThat(IsolatedLauncher.getLogLevel(props)).isEqualTo("WARN");
   }
 }

--- a/sonar-runner-dist/src/main/java/org/sonar/runner/Cli.java
+++ b/sonar-runner-dist/src/main/java/org/sonar/runner/Cli.java
@@ -65,10 +65,10 @@ class Cli {
         displayStackTrace = true;
 
       } else if ("-X".equals(arg) || "--debug".equals(arg)) {
-        props.setProperty("sonar.verbose", "true");
+        props.setProperty("sonar.logLevel", "DEBUG");
         displayStackTrace = true;
         debugMode = true;
-        Logs.setDebugEnabled(true);
+        Logs.setLogLevel(Logs.Level.DEBUG);
 
       } else if ("-D".equals(arg) || "--define".equals(arg)) {
         i++;
@@ -81,6 +81,28 @@ class Cli {
       } else if (arg.startsWith("-D")) {
         arg = arg.substring(2);
         appendPropertyTo(arg, props);
+
+      } else if ("-l".equals(arg) || "--logLevel".equals(arg)) {
+        i++;
+        if (i >= args.length) {
+          printError("Missing argument for option --logLevel");
+        }
+        arg = args[i];
+        props.setProperty("sonar.logLevel", arg);
+        if (arg.equals("DEBUG")) {
+          displayStackTrace = true;
+          debugMode = true;
+        }
+        Logs.setLogLevel(Logs.Level.valueOf(arg));
+
+      } else if (arg.startsWith("-l")) {
+        arg = arg.substring(2);
+        props.setProperty("sonar.logLevel", arg);
+        if (arg.equals("DEBUG")) {
+          displayStackTrace = true;
+          debugMode = true;
+        }
+        Logs.setLogLevel(Logs.Level.valueOf(arg));
 
       } else {
         printError("Unrecognized option: " + arg);
@@ -124,6 +146,7 @@ class Cli {
     Logs.info(" -h,--help             Display help information");
     Logs.info(" -v,--version          Display version information");
     Logs.info(" -X,--debug            Produce execution debug output");
+    Logs.info(" -l,--logLevel         Set log level");
     System.exit(Exit.SUCCESS);
   }
 }

--- a/sonar-runner-dist/src/main/java/org/sonar/runner/Stats.java
+++ b/sonar-runner-dist/src/main/java/org/sonar/runner/Stats.java
@@ -19,6 +19,8 @@
  */
 package org.sonar.runner;
 
+import org.sonar.runner.impl.Logs;
+
 class Stats {
   private long startTime;
 
@@ -32,12 +34,12 @@ class Stats {
 
   Stats stop() {
     long stopTime = System.currentTimeMillis() - startTime;
-    System.out.println("Total time: " + formatTime(stopTime));
+    Logs.info("Total time: " + formatTime(stopTime));
 
     System.gc();
     Runtime r = Runtime.getRuntime();
     long mb = 1024L * 1024;
-    System.out.println("Final Memory: " + (r.totalMemory() - r.freeMemory()) / mb + "M/" + r.totalMemory() / mb + "M");
+    Logs.info("Final Memory: " + (r.totalMemory() - r.freeMemory()) / mb + "M/" + r.totalMemory() / mb + "M");
 
     return this;
   }

--- a/sonar-runner-dist/src/main/java/org/sonar/runner/SystemInfo.java
+++ b/sonar-runner-dist/src/main/java/org/sonar/runner/SystemInfo.java
@@ -20,6 +20,7 @@
 package org.sonar.runner;
 
 import org.sonar.runner.api.RunnerVersion;
+import org.sonar.runner.impl.Logs;
 
 class SystemInfo {
 
@@ -28,12 +29,12 @@ class SystemInfo {
   }
 
   static void print() {
-    System.out.println("SonarQube Runner " + RunnerVersion.version());
-    System.out.println(java());
-    System.out.println(os());
+    Logs.info("SonarQube Runner " + RunnerVersion.version());
+    Logs.info(java());
+    Logs.info(os());
     String runnerOpts = System.getenv("SONAR_RUNNER_OPTS");
     if (runnerOpts != null) {
-      System.out.println("SONAR_RUNNER_OPTS=" + runnerOpts);
+      Logs.info("SONAR_RUNNER_OPTS=" + runnerOpts);
     }
   }
 

--- a/sonar-runner-dist/src/test/java/org/sonar/runner/CliTest.java
+++ b/sonar-runner-dist/src/test/java/org/sonar/runner/CliTest.java
@@ -58,7 +58,7 @@ public class CliTest {
     cli.parse(new String[]{"-X"});
     assertThat(cli.isDebugMode()).isTrue();
     assertThat(cli.isDisplayStackTrace()).isTrue();
-    assertThat(cli.properties().get("sonar.verbose")).isEqualTo("true");
+    assertThat(cli.properties().get("sonar.logLevel")).isEqualTo("DEBUG");
   }
 
   @Test
@@ -66,7 +66,7 @@ public class CliTest {
     cli.parse(new String[]{"-e"});
     assertThat(cli.isDebugMode()).isFalse();
     assertThat(cli.isDisplayStackTrace()).isTrue();
-    assertThat(cli.properties().get("sonar.verbose")).isNull();
+    assertThat(cli.properties().get("sonar.logLevel")).isNull();
   }
 
   @Test
@@ -74,6 +74,22 @@ public class CliTest {
     cli.parse(new String[0]);
     assertThat(cli.isDebugMode()).isFalse();
     assertThat(cli.isDisplayStackTrace()).isFalse();
-    assertThat(cli.properties().get("sonar.verbose")).isNull();
+    assertThat(cli.properties().get("sonar.logLevel")).isNull();
+  }
+
+  @Test
+  public void should_set_log_level() {
+    cli.parse(new String[]{"-l", "WARN"});
+    assertThat(cli.isDebugMode()).isFalse();
+    assertThat(cli.isDisplayStackTrace()).isFalse();
+    assertThat(cli.properties().get("sonar.logLevel")).isEqualTo("WARN");
+  }
+
+  @Test
+  public void should_enable_debug_mode_on_log_level_debug() {
+    cli.parse(new String[]{"-l", "DEBUG"});
+    assertThat(cli.isDebugMode()).isTrue();
+    assertThat(cli.isDisplayStackTrace()).isTrue();
+    assertThat(cli.properties().get("sonar.logLevel")).isEqualTo("DEBUG");
   }
 }

--- a/sonar-runner-impl/src/main/java/org/sonar/runner/impl/Logs.java
+++ b/sonar-runner-impl/src/main/java/org/sonar/runner/impl/Logs.java
@@ -19,42 +19,53 @@
  */
 package org.sonar.runner.impl;
 
+import static org.sonar.runner.impl.Logs.Level.DEBUG;
+import static org.sonar.runner.impl.Logs.Level.ERROR;
+import static org.sonar.runner.impl.Logs.Level.INFO;
+import static org.sonar.runner.impl.Logs.Level.WARN;
+
 public class Logs {
+  public static enum Level { ALL, TRACE, DEBUG, INFO, WARN, ERROR, OFF }
+
   private Logs() {
   }
 
-  private static boolean debugEnabled = false;
+  private static Level logLevel = INFO;
 
-  public static void setDebugEnabled(boolean debugEnabled) {
-    Logs.debugEnabled = debugEnabled;
-  }
-
-  public static boolean isDebugEnabled() {
-    return debugEnabled;
+  public static void setLogLevel(Level logLevel) {
+    Logs.logLevel = logLevel;
   }
 
   public static void debug(String message) {
-    if (isDebugEnabled()) {
+    if (logLevel.ordinal() <= DEBUG.ordinal()) {
       System.out.println("DEBUG: " + message);
     }
   }
 
   public static void info(String message) {
-    System.out.println("INFO: " + message);
+    if (logLevel.ordinal() <= INFO.ordinal()) {
+      System.out.println("INFO: " + message);
+    }
   }
 
   public static void warn(String message) {
-    System.out.println("WARN: " + message);
+    if (logLevel.ordinal() <= WARN.ordinal()) {
+      System.out.println("WARN: " + message);
+    }
   }
 
   public static void error(String message) {
-    System.err.println("ERROR: " + message);
+    if (logLevel.ordinal() <= ERROR.ordinal()) {
+      System.err.println("ERROR: " + message);
+    }
   }
 
   public static void error(String message, Throwable t) {
-    System.err.println("ERROR: " + message);
-    if (t != null) {
-      t.printStackTrace(System.err);
+    if (logLevel.ordinal() <= ERROR.ordinal()) {
+      System.err.println("ERROR: " + message);
+      if (t != null) {
+        t.printStackTrace(System.err);
+      }
     }
   }
 }


### PR DESCRIPTION
I'd like to be able to specify the log level if I do a sonar analysis.
E. G. when starting an analysis from a cron job on linux, I want the log level to be WARN, to get the warnings mailed.
Currently this can only be done by filtering out INFO lines from the output with various patterns.
I'd like to be able to control this from sonar-runner with a command line switch.
So here is the sonarqube-runner part, the according pull request for the sonarqube part is at https://github.com/SonarSource/sonarqube/pull/38